### PR TITLE
added special redirect rule for ABCD concepts

### DIFF
--- a/vhosts/wiki.tdwg.org.conf
+++ b/vhosts/wiki.tdwg.org.conf
@@ -15,6 +15,9 @@
   RewriteRule ^/$ https://github.com/tdwg/wiki-archive [L,R=301]
   RewriteRule ^/twiki/$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data [L,R=301]
 
+  # Rule to redirect pages to github wiki archive text pages, (?:bin/view/)? is the syntax of a non capturing optional group, to reduce the number of rules
+  RewriteRule ^/twiki/(?:bin/view/)?ABCD/AbcdConcept(\d\d\d\d)$ http://terms.tdwg.org/wiki/abcd2:$1 [L,R=301]
+  
   # Rule to redirect pages to github wiki archive text pages
   RewriteRule ^/twiki/bin/view/([^/]*)/([^/]*)$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/$2.txt [L,R=301]
   RewriteRule ^/twiki/([^/]*)/([^/]*)$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/$2.txt [L,R=301]


### PR DESCRIPTION
In the context of the ABCD 3.0 Project (http://abcd.biowikifarm.net/), the old documentation of ABCD 2.06 has been consolidated, cleaned up and imported in the TDWG Terms Wiki. All of the concepts are now available there, as well as dedicated redirects based on the old TDWG Wiki Numbers (e.g. http://wiki.tdwg.org/twiki/bin/view/ABCD/AbcdConcept0870 is now available via http://terms.tdwg.org/wiki/abcd2:0870). This change will redirect all of the pages to the corresponding pages in the TDWG Terms Wiki. 
