### PR TITLE
added redirect for ABCD 2 Terms

### DIFF
--- a/vhosts/rs.tdwg.org.conf
+++ b/vhosts/rs.tdwg.org.conf
@@ -99,5 +99,8 @@
    # proxy from github
    ProxyPass /sdd http://tdwg.github.io/sdd/
    ProxyPass /UBIF http://tdwg.github.io/sdd/
+ 
+ ### ABCD ###
+   RewriteRule ^/abcd2/terms/([a-zA-Z0-9-]+)$ http://terms.tdwg.org/wiki/abcd2:$1 [NE,R=303]
    
 </VirtualHost>

--- a/vhosts/rs.tdwg.org.conf
+++ b/vhosts/rs.tdwg.org.conf
@@ -101,6 +101,6 @@
    ProxyPass /UBIF http://tdwg.github.io/sdd/
  
  ### ABCD ###
-   RewriteRule ^/abcd2/terms/([a-zA-Z0-9-]+)$ http://terms.tdwg.org/wiki/abcd2:$1 [NE,R=303]
+   RewriteRule ^/abcd2/terms/([a-zA-Z0-9-@]+)$ http://terms.tdwg.org/wiki/abcd2:$1 [NE,R=303]
    
 </VirtualHost>


### PR DESCRIPTION
The terms are now documented in the TDWG Terms Wiki. This only applies for the current ABCD 2 concepts. The reworked concepts for the upcoming version ABCD 3 will use a different namespace. 