### PR TITLE
fixed redirect to wiki pages

### DIFF
--- a/vhosts/wiki.tdwg.org.conf
+++ b/vhosts/wiki.tdwg.org.conf
@@ -19,7 +19,7 @@
   RewriteRule ^/twiki/(?:bin/view/)?ABCD/AbcdConcept(\d\d\d\d)$ http://terms.tdwg.org/wiki/abcd2:$1 [L,R=301]
   
   # Generic redirect to WebHome page when the page name is not given 
-  # RewriteRule ^/twiki/(?:bin/view/)?([^/]*)/?$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/WebHome.txt [L,R=301]
+  RewriteRule ^/twiki/(?:bin/view/)?([^/]*)/?$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/WebHome.txt [L,R=301]
   
   # Rule to redirect pages to github wiki archive text pages
   RewriteRule ^/twiki/bin/view/([^/]*)/([^/]*)$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/$2.txt [L,R=301]

--- a/vhosts/wiki.tdwg.org.conf
+++ b/vhosts/wiki.tdwg.org.conf
@@ -18,6 +18,9 @@
   # Rule to redirect pages to github wiki archive text pages, (?:bin/view/)? is the syntax of a non capturing optional group, to reduce the number of rules
   RewriteRule ^/twiki/(?:bin/view/)?ABCD/AbcdConcept(\d\d\d\d)$ http://terms.tdwg.org/wiki/abcd2:$1 [L,R=301]
   
+  # Generic redirect to WebHome page when the page name is not given 
+  # RewriteRule ^/twiki/(?:bin/view/)?([^/]*)/?$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/WebHome.txt [L,R=301]
+  
   # Rule to redirect pages to github wiki archive text pages
   RewriteRule ^/twiki/bin/view/([^/]*)/([^/]*)$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/$2.txt [L,R=301]
   RewriteRule ^/twiki/([^/]*)/([^/]*)$ https://github.com/tdwg/wiki-archive/tree/master/twiki/data/$1/$2.txt [L,R=301]


### PR DESCRIPTION
a link like http://wiki.tdwg.org/twiki/bin/view/ABCD/ (without the second capture group) redirected to https://github.com/tdwg/wiki-archive/tree/master/twiki/data/ABCD/.txt which throws a 404. When the second part is not specified the WebHome page should be displayed for all wiki sections. This is now fixed.