### PR TITLE
added redirect for abcd content on rs.tdwg.org

### DIFF
--- a/vhosts/rs.tdwg.org.conf
+++ b/vhosts/rs.tdwg.org.conf
@@ -101,6 +101,10 @@
    ProxyPass /UBIF http://tdwg.github.io/sdd/
  
  ### ABCD ###
+   # redirect request from old domain to the files hosted at github repository
+   RewriteRule ^/abcd(/.*)?$ http://tdwg.github.io/abcd/$1
+   
+   # redirect ABCD 2 term identifier to the conresponding pages on the TDWG terms wiki
    RewriteRule ^/abcd2/terms/([a-zA-Z0-9-@]+)$ http://terms.tdwg.org/wiki/abcd2:$1 [NE,R=303]
    
 </VirtualHost>


### PR DESCRIPTION
this should fix tdwg/abcd#4 in combination with tdwg/abcd@89291d1e33fdd0d94f105a59039b04abbf2c85f4