### PR TITLE
added rewrite rule for ABCD EFG Terms

### DIFF
--- a/vhosts/rs.tdwg.org.conf
+++ b/vhosts/rs.tdwg.org.conf
@@ -102,7 +102,10 @@
  
  ### ABCD ###
    RewriteRule ^/abcd2/terms/([a-zA-Z0-9-@]+)$ http://terms.tdwg.org/wiki/abcd2:$1 [NE,R=303]
-   # proxy for github
+   RewriteRule ^/abcd-efg/terms/([a-zA-Z0-9-@]+)$ http://terms.tdwg.org/wiki/abcd-efg:$1 [NE,R=303]
+   
+   
+   # proxy for old abcd pages to github pages
    ProxyPass /abcd http://tdwg.github.io/abcd/
    
 </VirtualHost>


### PR DESCRIPTION
the ABCD EFG (Extended for Geosciences) Terms have now also been imported into the TDWG Terms wiki: http://terms.tdwg.org/wiki/ABCD_EFG